### PR TITLE
Slice 1: plumb RetrievalRequest through the retrieval pipeline

### DIFF
--- a/memory_module/__init__.py
+++ b/memory_module/__init__.py
@@ -10,6 +10,7 @@ __version__ = "0.1.0"
 # Import and expose main classes
 from .rag_pipeline import RAGPipeline
 from .retrieval.base_retrieval import BaseRetrievalStrategy
+from .retrieval.data_models import RetrievalRequest
 from .vector_db.base_vector_db import BaseVectorMemory
 from .vector_db.qdrant_vector_db import QdrantVectorMemory
 from .chunking.data_models import Chunk
@@ -17,6 +18,7 @@ from .chunking.data_models import Chunk
 __all__ = [
     "RAGPipeline",
     "BaseRetrievalStrategy",
+    "RetrievalRequest",
     "BaseVectorMemory",
     "QdrantVectorMemory",
     "Chunk",

--- a/memory_module/chunking/base_chunker.py
+++ b/memory_module/chunking/base_chunker.py
@@ -8,14 +8,7 @@ from ..parser.data_models import DocumentParserResult
 #---The chunker needs to handle the metadata formation as well---
 class BaseChunker(ABC):
     @abstractmethod
-    def chunk(self, parsed_document: DocumentParserResult, metadata: Dict) -> List[Chunk]:
-        """
-        Abstract method to chunk a document into smaller units.
-        
-        :param document_text: Full text of the document
-        :param metadata: Dict containing metadata like document_id, title, etc.
-        :return: List of Chunk objects
-        """
+    def chunk(self, parsed_document: DocumentParserResult, extra: Dict) -> List[Chunk]:
         pass
 
     def _generate_chunk_metadata(self, metadata: Dict) -> ChunkMetadata:

--- a/memory_module/chunking/document_chunker.py
+++ b/memory_module/chunking/document_chunker.py
@@ -29,8 +29,8 @@ class DocumentChunker(BaseChunker):
             chunk_overlap=chunk_overlap,
         )
 
-    def chunk(self, parsed_document: DocumentParserResult, metadata: Dict) -> List[Chunk]:
-        chunk_metadata_input = self._build_chunk_metadata_input(parsed_document, metadata)
+    def chunk(self, parsed_document: DocumentParserResult, extra: Dict) -> List[Chunk]:
+        chunk_metadata_input = self._build_chunk_metadata_input(parsed_document, extra)
         chunk_objects = []
 
         if parsed_document.content.mode == "text":
@@ -64,7 +64,7 @@ class DocumentChunker(BaseChunker):
     def _build_chunk_metadata_input(
         self,
         parsed_document: DocumentParserResult,
-        metadata: Dict,
+        extra: Dict,
     ) -> Dict:
         parser_metadata = parsed_document.file_metadata
         if parser_metadata is None:
@@ -75,7 +75,7 @@ class DocumentChunker(BaseChunker):
             "document_title": parser_metadata.document_title,
         }
 
-        caller_tags = (metadata or {}).get("tags")
+        caller_tags = (extra or {}).get("tags")
         if caller_tags is not None:
             chunk_metadata_input["tags"] = caller_tags
 

--- a/memory_module/rag_pipeline.py
+++ b/memory_module/rag_pipeline.py
@@ -10,6 +10,7 @@ from .factory.retrieval_factory import get_retrieval_strategy
 from .factory.vector_db_factory import get_vector_db
 from .parser.document_parser_base import DocumentParserBase
 from .retrieval.base_retrieval import BaseRetrievalStrategy
+from .retrieval.data_models import RetrievalRequest
 from .vector_db.base_vector_db import BaseVectorMemory
 
 
@@ -109,7 +110,7 @@ class RAGPipeline:
             raise ValueError("Parser does not accept the provided document.")
 
         parsed_document = self.parser.convert(document)
-        chunks = self.chunker.chunk(parsed_document, metadata or {})
+        chunks = self.chunker.chunk(parsed_document, extra=metadata or {})
 
         for chunk in chunks:
             embedding = self.embedder.embed(chunk.text)
@@ -137,8 +138,10 @@ class RAGPipeline:
         if embedded_query and isinstance(embedded_query[0], list):
             embedded_query = embedded_query[0]
 
-        return self.retriever.retrieve(
-            embedded_query=embedded_query,
+        request = RetrievalRequest(
+            query_text=query,
+            query_embedding=embedded_query,
             top_k=top_k,
             filters=filters,
         )
+        return self.retriever.retrieve(request)

--- a/memory_module/retrieval/base_retrieval.py
+++ b/memory_module/retrieval/base_retrieval.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import List
 
 from ..chunking.data_models import Chunk
 from ..vector_db.base_vector_db import BaseVectorMemory
+from .data_models import RetrievalRequest
 
 
 class BaseRetrievalStrategy(ABC):
@@ -10,10 +11,5 @@ class BaseRetrievalStrategy(ABC):
         self.vector_db = vector_db
 
     @abstractmethod
-    def retrieve(
-        self,
-        embedded_query: List[float],
-        top_k: int = 5,
-        filters: Optional[Dict[str, Any]] = None,
-    ) -> List[Chunk]:
+    def retrieve(self, request: RetrievalRequest) -> List[Chunk]:
         pass

--- a/memory_module/retrieval/data_models.py
+++ b/memory_module/retrieval/data_models.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class RetrievalRequest(BaseModel):
+    query_text: str
+    query_embedding: list[float]
+    top_k: int = 5
+    filters: dict | None = None

--- a/memory_module/retrieval/similarity_retrieval.py
+++ b/memory_module/retrieval/similarity_retrieval.py
@@ -1,19 +1,16 @@
-from typing import Any, Dict, List, Optional
+from typing import List
 
 from ..chunking.data_models import Chunk
 from .base_retrieval import BaseRetrievalStrategy
+from .data_models import RetrievalRequest
+
 
 class SimilarityRetrievalStrategy(BaseRetrievalStrategy):
-    def retrieve(
-        self,
-        embedded_query: List[float],
-        top_k: int = 5,
-        filters: Optional[Dict[str, Any]] = None,
-    ) -> List[Chunk]:
+    def retrieve(self, request: RetrievalRequest) -> List[Chunk]:
         if self.vector_db is None:
             raise RuntimeError("SimilarityRetrievalStrategy requires a vector_db.")
         return self.vector_db.retrieve(
-            embedded_query=embedded_query,
-            top_k=top_k,
-            filters=filters,
+            embedded_query=request.query_embedding,
+            top_k=request.top_k,
+            filters=request.filters,
         )

--- a/tests/chunking/test_document_chunker.py
+++ b/tests/chunking/test_document_chunker.py
@@ -15,6 +15,14 @@ def test_chunker_uses_parsed_document_text(parsed_document):
     assert all(chunk.metadata.document_id == "doc_test" for chunk in chunks)
 
 
+def test_chunker_accepts_extra_keyword(parsed_document):
+    chunker = DocumentChunker(chunk_size=5, chunk_overlap=0, tokenizer="character")
+
+    chunks = chunker.chunk(parsed_document, extra={"tags": ["z"]})
+
+    assert chunks[0].metadata.tags == ["z"]
+
+
 def test_chunker_includes_tags_and_chunk_version(parsed_document):
     chunker = DocumentChunker(chunk_size=5, chunk_overlap=0, tokenizer="character")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,8 +111,8 @@ class StubChunker:
         self._chunks = chunks
         self.calls: list[tuple[str, Any]] = []
 
-    def chunk(self, parsed_document: DocumentParserResult, metadata: dict[str, Any]) -> list[Chunk]:
-        self.calls.append(("chunk", parsed_document, metadata))
+    def chunk(self, parsed_document: DocumentParserResult, extra: dict[str, Any]) -> list[Chunk]:
+        self.calls.append(("chunk", parsed_document, extra))
         return self._chunks
 
 

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -3,6 +3,7 @@ import pytest
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
 from memory_module.parser.data_models import DocumentParserResult, FileMetadata, ParsedContent
 from memory_module.rag_pipeline import RAGPipeline
+from memory_module.retrieval.data_models import RetrievalRequest
 from tests.conftest import StubChunker, StubEmbedder, StubParser, StubVectorDB
 
 
@@ -68,8 +69,8 @@ def test_retrieve_embeds_query_and_delegates_to_retrieval_strategy(sample_chunk)
         def __init__(self):
             self.calls = []
 
-        def retrieve(self, embedded_query, top_k=5, filters=None):
-            self.calls.append((embedded_query, top_k, filters))
+        def retrieve(self, request: RetrievalRequest):
+            self.calls.append(request)
             return [sample_chunk]
 
     pipeline = RAGPipeline({})
@@ -80,13 +81,18 @@ def test_retrieve_embeds_query_and_delegates_to_retrieval_strategy(sample_chunk)
 
     assert results == [sample_chunk]
     assert pipeline.embedder.calls == ["hello"]
-    assert pipeline.retriever.calls == [([0.3, 0.4], 3, {"tags": "x"})]
+    assert len(pipeline.retriever.calls) == 1
+    req = pipeline.retriever.calls[0]
+    assert req.query_text == "hello"
+    assert req.query_embedding == [0.3, 0.4]
+    assert req.top_k == 3
+    assert req.filters == {"tags": "x"}
 
 
 def test_retrieve_flattens_batch_embeddings(sample_chunk):
     class RetrieveStrategy:
-        def retrieve(self, embedded_query, top_k=5, filters=None):
-            self.embedded_query = embedded_query
+        def retrieve(self, request: RetrievalRequest):
+            self.request = request
             return [sample_chunk]
 
     pipeline = RAGPipeline({})
@@ -95,7 +101,7 @@ def test_retrieve_flattens_batch_embeddings(sample_chunk):
 
     pipeline.retrieve("hello")
 
-    assert pipeline.retriever.embedded_query == [0.3, 0.4]
+    assert pipeline.retriever.request.query_embedding == [0.3, 0.4]
 
 
 def test_retrieve_requires_embedder_and_retrieval_strategy():

--- a/tests/retrieval/test_retrieval_request.py
+++ b/tests/retrieval/test_retrieval_request.py
@@ -1,0 +1,31 @@
+import pytest
+
+from memory_module.retrieval.data_models import RetrievalRequest
+
+
+def test_retrieval_request_requires_query_text_and_embedding():
+    req = RetrievalRequest(query_text="hello", query_embedding=[0.1, 0.2])
+    assert req.query_text == "hello"
+    assert req.query_embedding == [0.1, 0.2]
+
+
+def test_retrieval_request_defaults():
+    req = RetrievalRequest(query_text="hello", query_embedding=[0.1])
+    assert req.top_k == 5
+    assert req.filters is None
+
+
+def test_retrieval_request_accepts_filters_and_top_k():
+    req = RetrievalRequest(
+        query_text="hello",
+        query_embedding=[0.1],
+        top_k=10,
+        filters={"tag": "x"},
+    )
+    assert req.top_k == 10
+    assert req.filters == {"tag": "x"}
+
+
+def test_retrieval_request_rejects_missing_required_fields():
+    with pytest.raises(Exception):
+        RetrievalRequest(query_text="hello")  # type: ignore[call-arg]

--- a/tests/retrieval/test_similarity_retrieval.py
+++ b/tests/retrieval/test_similarity_retrieval.py
@@ -1,6 +1,7 @@
 import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
+from memory_module.retrieval.data_models import RetrievalRequest
 from memory_module.retrieval.similarity_retrieval import SimilarityRetrievalStrategy
 
 
@@ -24,12 +25,14 @@ class StubVectorDB:
 def test_similarity_retrieval_uses_self_vector_db():
     vector_db = StubVectorDB()
     strategy = SimilarityRetrievalStrategy(vector_db=vector_db)
-
-    results = strategy.retrieve(
-        embedded_query=[0.1, 0.2],
+    request = RetrievalRequest(
+        query_text="hello",
+        query_embedding=[0.1, 0.2],
         top_k=3,
         filters={"metadata.tags": "a"},
     )
+
+    results = strategy.retrieve(request)
 
     assert results[0].chunk_id == "chunk-1"
     assert vector_db.calls == [([0.1, 0.2], 3, {"metadata.tags": "a"})]
@@ -37,6 +40,7 @@ def test_similarity_retrieval_uses_self_vector_db():
 
 def test_similarity_retrieval_requires_vector_db():
     strategy = SimilarityRetrievalStrategy()
+    request = RetrievalRequest(query_text="hello", query_embedding=[0.1, 0.2])
 
     with pytest.raises(RuntimeError, match="requires a vector_db"):
-        strategy.retrieve(embedded_query=[0.1, 0.2])
+        strategy.retrieve(request)


### PR DESCRIPTION
## Summary

- Add `RetrievalRequest` Pydantic model (`query_text`, `query_embedding`, `top_k=5`, `filters=None`) in `memory_module/retrieval/data_models.py`
- Update `BaseRetrievalStrategy.retrieve()` and `SimilarityRetrievalStrategy` to accept `RetrievalRequest` instead of individual kwargs
- `RAGPipeline.retrieve` now constructs a `RetrievalRequest` before calling the retriever strategy
- Rename `metadata` → `extra` in `BaseChunker.chunk` and `DocumentChunker.chunk` (callers updated accordingly)
- Export `RetrievalRequest` from the top-level package

Closes #2

## Test plan

- [ ] `tests/retrieval/test_retrieval_request.py` — new tests covering model construction, defaults, and validation
- [ ] `tests/retrieval/test_similarity_retrieval.py` — updated to pass `RetrievalRequest`; verifies vector_db receives correct unpacked fields
- [ ] `tests/pipeline/test_rag_pipeline_indexer.py` — updated stubs accept `RetrievalRequest`; asserts `query_text`, `query_embedding`, `top_k`, and `filters` are populated correctly by the pipeline
- [ ] `tests/chunking/test_document_chunker.py` — new `test_chunker_accepts_extra_keyword` confirms renamed parameter works

🤖 Generated with [Claude Code](https://claude.com/claude-code)