### PR TITLE
Slice 2: propagate ScoredChunk end-to-end (vector DB through HTTP)

### DIFF
--- a/memory_module/example_usage.py
+++ b/memory_module/example_usage.py
@@ -72,13 +72,13 @@ def main():
     query_vector = [0.2, 0.3, 0.4, 0.5]  # Similar to the second chunk
     results = memory.retrieve(embedded_query=query_vector, top_k=2)
     
-    for i, chunk in enumerate(results):
-        print(f"\nResult {i+1}:")
-        print(f"ID: {chunk.chunk_id}")
-        print(f"Text: {chunk.text}")
-        print(f"Metadata: {chunk.metadata}")
-        print(f"Created At: {chunk.metadata.created_at}")
-    
+    for i, scored in enumerate(results):
+        print(f"\nResult {i+1} (score={scored.score:.4f}):")
+        print(f"ID: {scored.chunk.chunk_id}")
+        print(f"Text: {scored.chunk.text}")
+        print(f"Metadata: {scored.chunk.metadata}")
+        print(f"Created At: {scored.chunk.metadata.created_at}")
+
     # Retrieve chunks with filter
     print("\nRetrieving chunks with filter...")
     filtered_results = memory.retrieve(
@@ -86,12 +86,12 @@ def main():
         top_k=2,
         filters={"metadata.tags": "programming"}
     )
-    
-    for i, chunk in enumerate(filtered_results):
-        print(f"\nFiltered Result {i+1}:")
-        print(f"ID: {chunk.chunk_id}")
-        print(f"Text: {chunk.text}")
-        print(f"Metadata: {chunk.metadata}")
+
+    for i, scored in enumerate(filtered_results):
+        print(f"\nFiltered Result {i+1} (score={scored.score:.4f}):")
+        print(f"ID: {scored.chunk.chunk_id}")
+        print(f"Text: {scored.chunk.text}")
+        print(f"Metadata: {scored.chunk.metadata}")
     
     # Delete a chunk
     if chunks:
@@ -101,7 +101,7 @@ def main():
         
         # Verify deletion
         all_results = memory.retrieve(embedded_query=query_vector, top_k=10)
-        remaining_ids = [chunk.chunk_id for chunk in all_results]
+        remaining_ids = [scored.chunk.chunk_id for scored in all_results]
         
         if chunk_to_delete not in remaining_ids:
             print(f"Successfully deleted chunk with ID: {chunk_to_delete}")

--- a/memory_module/retrieval/base_retrieval.py
+++ b/memory_module/retrieval/base_retrieval.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from ..chunking.data_models import Chunk
 from ..vector_db.base_vector_db import BaseVectorMemory
-from .data_models import RetrievalRequest
+from .data_models import RetrievalRequest, ScoredChunk
 
 
 class BaseRetrievalStrategy(ABC):
@@ -11,5 +10,5 @@ class BaseRetrievalStrategy(ABC):
         self.vector_db = vector_db
 
     @abstractmethod
-    def retrieve(self, request: RetrievalRequest) -> List[Chunk]:
+    def retrieve(self, request: RetrievalRequest) -> List[ScoredChunk]:
         pass

--- a/memory_module/retrieval/data_models.py
+++ b/memory_module/retrieval/data_models.py
@@ -1,8 +1,15 @@
 from pydantic import BaseModel
 
+from ..chunking.data_models import Chunk
+
 
 class RetrievalRequest(BaseModel):
     query_text: str
     query_embedding: list[float]
     top_k: int = 5
     filters: dict | None = None
+
+
+class ScoredChunk(BaseModel):
+    chunk: Chunk
+    score: float

--- a/memory_module/retrieval/similarity_retrieval.py
+++ b/memory_module/retrieval/similarity_retrieval.py
@@ -1,12 +1,11 @@
 from typing import List
 
-from ..chunking.data_models import Chunk
 from .base_retrieval import BaseRetrievalStrategy
-from .data_models import RetrievalRequest
+from .data_models import RetrievalRequest, ScoredChunk
 
 
 class SimilarityRetrievalStrategy(BaseRetrievalStrategy):
-    def retrieve(self, request: RetrievalRequest) -> List[Chunk]:
+    def retrieve(self, request: RetrievalRequest) -> List[ScoredChunk]:
         if self.vector_db is None:
             raise RuntimeError("SimilarityRetrievalStrategy requires a vector_db.")
         return self.vector_db.retrieve(

--- a/memory_module/vector_db/base_vector_db.py
+++ b/memory_module/vector_db/base_vector_db.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from ..chunking.data_models import Chunk
+from ..retrieval.data_models import ScoredChunk
 
 class BaseVectorMemory(ABC):
     """
@@ -21,7 +22,7 @@ class BaseVectorMemory(ABC):
         embedded_query: List[float],
         top_k: int = 5,
         filters: Optional[Dict[str, Any]] = None
-    ) -> List[Chunk]:
+    ) -> List[ScoredChunk]:
         """
         Retrieve memory chunks based on semantic similarity + metadata filters.
         """

--- a/memory_module/vector_db/qdrant_vector_db.py
+++ b/memory_module/vector_db/qdrant_vector_db.py
@@ -7,6 +7,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams, PointStruct, Filter, FieldCondition, MatchValue
 from .base_vector_db import BaseVectorMemory
 from ..chunking.data_models import Chunk, ChunkMetadata
+from ..retrieval.data_models import ScoredChunk
 
 load_dotenv()
 
@@ -119,7 +120,7 @@ class QdrantVectorMemory(BaseVectorMemory):
         embedded_query: List[float],
         top_k: int = 5,
         filters: Optional[Dict[str, Any]] = None
-    ) -> List[Chunk]:
+    ) -> List[ScoredChunk]:
         """
         Retrieve memory chunks based on semantic similarity + metadata filters.
         
@@ -169,10 +170,8 @@ class QdrantVectorMemory(BaseVectorMemory):
                 query_filter=qdrant_filter
             )
             
-            # Convert search results to Chunk objects
-            chunks = []
+            scored_chunks = []
             for result in search_result:
-                # Extract data from payload
                 payload = result.payload
                 text = payload.get("text", "")
                 metadata_dict = payload.get("metadata", {})
@@ -183,8 +182,7 @@ class QdrantVectorMemory(BaseVectorMemory):
                         created_at = datetime.fromisoformat(created_at_value)
                     except ValueError:
                         created_at = datetime.utcnow()
-                
-                # Create ChunkMetadata
+
                 metadata = ChunkMetadata(
                     document_id=metadata_dict.get("document_id", ""),
                     document_title=metadata_dict.get("document_title"),
@@ -192,8 +190,7 @@ class QdrantVectorMemory(BaseVectorMemory):
                     tags=metadata_dict.get("tags"),
                     chunk_version=metadata_dict.get("chunk_version")
                 )
-                
-                # Create Chunk
+
                 chunk = Chunk(
                     chunk_id=str(result.id),
                     text=text,
@@ -201,9 +198,9 @@ class QdrantVectorMemory(BaseVectorMemory):
                     metadata=metadata,
                     token_count=payload.get("token_count"),
                 )
-                chunks.append(chunk)
-            
-            return chunks
+                scored_chunks.append(ScoredChunk(chunk=chunk, score=result.score))
+
+            return scored_chunks
         
         except Exception as e:
             raise RuntimeError(f"Failed to retrieve chunks from Qdrant: {str(e)}")

--- a/tests/app/test_main_api.py
+++ b/tests/app/test_main_api.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 import main
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
+from memory_module.retrieval.data_models import ScoredChunk
 
 
 def test_index_endpoint_success(monkeypatch):
@@ -40,12 +41,15 @@ def test_index_endpoint_success(monkeypatch):
 def test_retrieve_endpoint_success(monkeypatch):
     pipeline = MagicMock()
     pipeline.retrieve.return_value = [
-        Chunk(
-            chunk_id="chunk-1",
-            text="hello",
-            embedding=[0.1],
-            metadata=ChunkMetadata(document_id="doc-1"),
-            token_count=1,
+        ScoredChunk(
+            chunk=Chunk(
+                chunk_id="chunk-1",
+                text="hello",
+                embedding=[0.1],
+                metadata=ChunkMetadata(document_id="doc-1"),
+                token_count=1,
+            ),
+            score=0.87,
         )
     ]
     monkeypatch.setattr(main, "RAGPipeline", lambda config: pipeline)
@@ -65,7 +69,9 @@ def test_retrieve_endpoint_success(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert response.json()[0]["chunk_id"] == "chunk-1"
+    result = response.json()[0]
+    assert result["score"] == 0.87
+    assert result["chunk"]["chunk_id"] == "chunk-1"
     pipeline.retrieve.assert_called_once_with(
         query="hello",
         top_k=3,

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -3,7 +3,7 @@ import pytest
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
 from memory_module.parser.data_models import DocumentParserResult, FileMetadata, ParsedContent
 from memory_module.rag_pipeline import RAGPipeline
-from memory_module.retrieval.data_models import RetrievalRequest
+from memory_module.retrieval.data_models import RetrievalRequest, ScoredChunk
 from tests.conftest import StubChunker, StubEmbedder, StubParser, StubVectorDB
 
 
@@ -64,14 +64,16 @@ def test_indexer_flattens_batch_embedding(upload_docx):
     assert result[0].embedding == [0.1, 0.2]
 
 
-def test_retrieve_embeds_query_and_delegates_to_retrieval_strategy(sample_chunk):
+def test_retrieve_returns_scored_chunks(sample_chunk):
+    scored = ScoredChunk(chunk=sample_chunk, score=0.9)
+
     class RetrieveStrategy:
         def __init__(self):
             self.calls = []
 
         def retrieve(self, request: RetrievalRequest):
             self.calls.append(request)
-            return [sample_chunk]
+            return [scored]
 
     pipeline = RAGPipeline({})
     pipeline.embedder = StubEmbedder([0.3, 0.4])
@@ -79,7 +81,9 @@ def test_retrieve_embeds_query_and_delegates_to_retrieval_strategy(sample_chunk)
 
     results = pipeline.retrieve("hello", top_k=3, filters={"tags": "x"})
 
-    assert results == [sample_chunk]
+    assert results == [scored]
+    assert isinstance(results[0], ScoredChunk)
+    assert results[0].score == 0.9
     assert pipeline.embedder.calls == ["hello"]
     assert len(pipeline.retriever.calls) == 1
     req = pipeline.retriever.calls[0]
@@ -90,10 +94,12 @@ def test_retrieve_embeds_query_and_delegates_to_retrieval_strategy(sample_chunk)
 
 
 def test_retrieve_flattens_batch_embeddings(sample_chunk):
+    scored = ScoredChunk(chunk=sample_chunk, score=0.5)
+
     class RetrieveStrategy:
         def retrieve(self, request: RetrievalRequest):
             self.request = request
-            return [sample_chunk]
+            return [scored]
 
     pipeline = RAGPipeline({})
     pipeline.embedder = StubEmbedder([[0.3, 0.4]])

--- a/tests/retrieval/test_similarity_retrieval.py
+++ b/tests/retrieval/test_similarity_retrieval.py
@@ -1,7 +1,7 @@
 import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
-from memory_module.retrieval.data_models import RetrievalRequest
+from memory_module.retrieval.data_models import RetrievalRequest, ScoredChunk
 from memory_module.retrieval.similarity_retrieval import SimilarityRetrievalStrategy
 
 
@@ -12,17 +12,20 @@ class StubVectorDB:
     def retrieve(self, embedded_query, top_k=5, filters=None):
         self.calls.append((embedded_query, top_k, filters))
         return [
-            Chunk(
-                chunk_id="chunk-1",
-                text="hello",
-                embedding=[0.1],
-                metadata=ChunkMetadata(document_id="doc-1"),
-                token_count=1,
+            ScoredChunk(
+                chunk=Chunk(
+                    chunk_id="chunk-1",
+                    text="hello",
+                    embedding=[0.1],
+                    metadata=ChunkMetadata(document_id="doc-1"),
+                    token_count=1,
+                ),
+                score=0.87,
             )
         ]
 
 
-def test_similarity_retrieval_uses_self_vector_db():
+def test_similarity_retrieval_returns_scored_chunks():
     vector_db = StubVectorDB()
     strategy = SimilarityRetrievalStrategy(vector_db=vector_db)
     request = RetrievalRequest(
@@ -34,7 +37,9 @@ def test_similarity_retrieval_uses_self_vector_db():
 
     results = strategy.retrieve(request)
 
-    assert results[0].chunk_id == "chunk-1"
+    assert isinstance(results[0], ScoredChunk)
+    assert results[0].chunk.chunk_id == "chunk-1"
+    assert results[0].score == 0.87
     assert vector_db.calls == [([0.1, 0.2], 3, {"metadata.tags": "a"})]
 
 

--- a/tests/vector_db/test_qdrant_vector_db.py
+++ b/tests/vector_db/test_qdrant_vector_db.py
@@ -6,6 +6,7 @@ import pytest
 from qdrant_client.models import PointStruct
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
+from memory_module.retrieval.data_models import ScoredChunk
 from memory_module.vector_db.qdrant_vector_db import QdrantVectorMemory
 
 
@@ -63,10 +64,11 @@ def test_add_chunks_serializes_current_payload_shape(mock_qdrant_client, sample_
     assert points[0].payload["metadata"]["document_id"] == "doc-1"
 
 
-def test_retrieve_rebuilds_chunks_from_payload(mock_qdrant_client):
+def test_retrieve_returns_scored_chunks_with_scores(mock_qdrant_client):
     mock_qdrant_client.search.return_value = [
         SimpleNamespace(
             id="chunk-1",
+            score=0.92,
             payload={
                 "text": "hello",
                 "token_count": 5,
@@ -86,9 +88,34 @@ def test_retrieve_rebuilds_chunks_from_payload(mock_qdrant_client):
     results = memory.retrieve([0.1, 0.2], top_k=1)
 
     assert len(results) == 1
-    assert results[0].chunk_id == "chunk-1"
-    assert results[0].metadata.document_id == "doc-1"
-    assert results[0].token_count == 5
+    assert isinstance(results[0], ScoredChunk)
+    assert results[0].score == 0.92
+    assert results[0].chunk.chunk_id == "chunk-1"
+    assert results[0].chunk.metadata.document_id == "doc-1"
+    assert results[0].chunk.token_count == 5
+
+
+def test_retrieve_preserves_score_from_qdrant(mock_qdrant_client):
+    mock_qdrant_client.search.return_value = [
+        SimpleNamespace(
+            id="a",
+            score=0.95,
+            payload={"text": "a", "token_count": 1, "metadata": {"document_id": "d1"}},
+            vector=[],
+        ),
+        SimpleNamespace(
+            id="b",
+            score=0.60,
+            payload={"text": "b", "token_count": 1, "metadata": {"document_id": "d2"}},
+            vector=[],
+        ),
+    ]
+
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+    results = memory.retrieve([0.1], top_k=2)
+
+    assert results[0].score == 0.95
+    assert results[1].score == 0.60
 
 
 def test_retrieve_builds_qdrant_filters(mock_qdrant_client):


### PR DESCRIPTION
Closes #3

## Summary

- Adds `ScoredChunk(chunk: Chunk, score: float)` Pydantic model to `retrieval/data_models.py`
- `BaseVectorMemory.retrieve` and `QdrantVectorDB.retrieve` now return `List[ScoredChunk]`; Qdrant scores are no longer discarded
- `BaseRetrievalStrategy.retrieve` and `SimilarityRetrievalStrategy.retrieve` return types updated to `List[ScoredChunk]`
- `/retrieve` HTTP response now serialises each result as `{chunk: {...}, score: 0.87}` via Pydantic default serialisation (no endpoint code change needed)
- `example_usage.py` updated to read `.chunk.*` from each `ScoredChunk`
- No backward-compatibility shims for old `List[Chunk]` return types

## Test plan

- `tests/retrieval/test_similarity_retrieval.py` — asserts `List[ScoredChunk]` returned and scores propagated from stub vector DB
- `tests/vector_db/test_qdrant_vector_db.py` — two new tests confirm score is preserved from Qdrant client response
- `tests/pipeline/test_rag_pipeline_indexer.py` — retrieve-path test asserts pipeline returns `List[ScoredChunk]`
- `tests/app/test_main_api.py` — `/retrieve` response shape asserted as `{chunk, score}`
- `pytest` — 72 passing, same 3 pre-existing failures, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)