### PR TITLE
Slice 2: stage-failure errors (ParserRejected, EmbedderFailed, VectorDBFailed) + atomic abort

### DIFF
--- a/memory_module/errors.py
+++ b/memory_module/errors.py
@@ -8,3 +8,15 @@ class ConfigError(RAGError):
 
 class InvalidQuery(RAGError):
     code = "invalid_query"
+
+
+class ParserRejected(RAGError):
+    code = "parser_rejected"
+
+
+class EmbedderFailed(RAGError):
+    code = "embedder_failed"
+
+
+class VectorDBFailed(RAGError):
+    code = "vector_db_failed"

--- a/memory_module/rag_pipeline.py
+++ b/memory_module/rag_pipeline.py
@@ -3,7 +3,7 @@ from fastapi import UploadFile
 
 from .chunking.base_chunker import BaseChunker
 from .embedder.base_embedder import BaseEmbedder
-from .errors import ConfigError, InvalidQuery
+from .errors import ConfigError, EmbedderFailed, InvalidQuery, ParserRejected, VectorDBFailed
 from .factory.chunking_factory import get_chunker
 from .factory.embedder_factory import get_embedder
 from .factory.parser_factory import get_parser
@@ -107,19 +107,25 @@ class RAGPipeline:
         if hasattr(self.parser, "accepts") and not self.parser.accepts(document):
             parser_error = getattr(self.parser, "last_error", None)
             if parser_error:
-                raise ValueError(f"Parser rejected the provided document: {parser_error}")
-            raise ValueError("Parser does not accept the provided document.")
+                raise ParserRejected(f"Parser rejected the provided document: {parser_error}")
+            raise ParserRejected("Parser does not accept the provided document.")
 
         parsed_document = self.parser.convert(document)
         chunks = self.chunker.chunk(parsed_document, extra=metadata or {})
 
-        for chunk in chunks:
-            embedding = self.embedder.embed(chunk.text)
-            if embedding and isinstance(embedding[0], list):
-                embedding = embedding[0]
-            chunk.embedding = embedding
+        try:
+            for chunk in chunks:
+                embedding = self.embedder.embed(chunk.text)
+                if embedding and isinstance(embedding[0], list):
+                    embedding = embedding[0]
+                chunk.embedding = embedding
+        except Exception as exc:
+            raise EmbedderFailed("Embedder failed during indexing.") from exc
 
-        self.vector_db.add_chunks(chunks)
+        try:
+            self.vector_db.add_chunks(chunks)
+        except Exception as exc:
+            raise VectorDBFailed("Vector DB failed during indexing.") from exc
         return chunks
 
     def retrieve(
@@ -135,7 +141,10 @@ class RAGPipeline:
         if self.retriever is None:
             raise ConfigError("Retrieve requires a retrieval strategy.")
 
-        embedded_query = self.embedder.embed(query)
+        try:
+            embedded_query = self.embedder.embed(query)
+        except Exception as exc:
+            raise EmbedderFailed("Embedder failed on the query.") from exc
         if embedded_query and isinstance(embedded_query[0], list):
             embedded_query = embedded_query[0]
 
@@ -145,4 +154,7 @@ class RAGPipeline:
             top_k=top_k,
             filters=filters,
         )
-        return self.retriever.retrieve(request)
+        try:
+            return self.retriever.retrieve(request)
+        except Exception as exc:
+            raise VectorDBFailed("Vector DB failed during retrieval.") from exc

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
-from memory_module.errors import ConfigError, InvalidQuery
+from memory_module.errors import ConfigError, EmbedderFailed, InvalidQuery, ParserRejected, VectorDBFailed
 from memory_module.parser.data_models import DocumentParserResult, FileMetadata, ParsedContent
 from memory_module.rag_pipeline import RAGPipeline
 from memory_module.retrieval.data_models import RetrievalRequest, ScoredChunk
@@ -144,8 +144,113 @@ def test_indexer_raises_when_parser_rejects(upload_docx):
     pipeline.embedder = StubEmbedder([0.1])
     pipeline.vector_db = StubVectorDB()
 
-    with pytest.raises(ValueError, match="Parser rejected the provided document: Rejected for test"):
+    with pytest.raises(ParserRejected):
         pipeline.indexer(upload_docx)
+
+
+def test_indexer_raises_embedder_failed_and_skips_vector_db(upload_docx):
+    parsed_document = DocumentParserResult(
+        content=ParsedContent(mode="text", text="hello world", sections=[]),
+        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
+    )
+    chunks = [
+        Chunk(
+            chunk_id="chunk_1",
+            text="hello",
+            embedding=[],
+            metadata=ChunkMetadata(document_id="doc_1", chunk_version="doc_1_chunk_1"),
+            token_count=5,
+        )
+    ]
+
+    original = RuntimeError("embedder boom")
+
+    class FailingEmbedder:
+        def embed(self, text: str):
+            raise original
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = StubParser(parsed_document)
+    pipeline.chunker = StubChunker(chunks)
+    pipeline.embedder = FailingEmbedder()
+    pipeline.vector_db = StubVectorDB()
+
+    with pytest.raises(EmbedderFailed) as exc_info:
+        pipeline.indexer(upload_docx)
+
+    assert exc_info.value.__cause__ is original
+    assert pipeline.vector_db.added_chunks is None
+
+
+def test_retrieve_raises_embedder_failed():
+    original = RuntimeError("embedder boom")
+
+    class FailingEmbedder:
+        def embed(self, text: str):
+            raise original
+
+    class DummyRetriever:
+        def retrieve(self, request):
+            return []
+
+    pipeline = RAGPipeline({})
+    pipeline.embedder = FailingEmbedder()
+    pipeline.retriever = DummyRetriever()
+
+    with pytest.raises(EmbedderFailed) as exc_info:
+        pipeline.retrieve("hello")
+
+    assert exc_info.value.__cause__ is original
+
+
+def test_retrieve_raises_vector_db_failed():
+    original = RuntimeError("vector db down")
+
+    class FailingRetriever:
+        def retrieve(self, request):
+            raise original
+
+    pipeline = RAGPipeline({})
+    pipeline.embedder = StubEmbedder([0.1, 0.2])
+    pipeline.retriever = FailingRetriever()
+
+    with pytest.raises(VectorDBFailed) as exc_info:
+        pipeline.retrieve("hello")
+
+    assert exc_info.value.__cause__ is original
+
+
+def test_indexer_raises_vector_db_failed(upload_docx):
+    parsed_document = DocumentParserResult(
+        content=ParsedContent(mode="text", text="hello world", sections=[]),
+        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
+    )
+    chunks = [
+        Chunk(
+            chunk_id="chunk_1",
+            text="hello",
+            embedding=[],
+            metadata=ChunkMetadata(document_id="doc_1", chunk_version="doc_1_chunk_1"),
+            token_count=5,
+        )
+    ]
+
+    original = RuntimeError("vector db down")
+
+    class FailingVectorDB:
+        def add_chunks(self, chunks):
+            raise original
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = StubParser(parsed_document)
+    pipeline.chunker = StubChunker(chunks)
+    pipeline.embedder = StubEmbedder([0.1, 0.2])
+    pipeline.vector_db = FailingVectorDB()
+
+    with pytest.raises(VectorDBFailed) as exc_info:
+        pipeline.indexer(upload_docx)
+
+    assert exc_info.value.__cause__ is original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes #9. Adds the three stage-failure exceptions to the typed error hierarchy and wires `RAGPipeline` so each external stage call surfaces a typed failure with `__cause__` preserved.

- `memory_module/errors.py`: adds `ParserRejected` (`parser_rejected`), `EmbedderFailed` (`embedder_failed`), `VectorDBFailed` (`vector_db_failed`), each inheriting `RAGError`.
- `RAGPipeline.indexer`: parser-accepts branch raises `ParserRejected` (replaces the previous `ValueError`); per-stage `try/except` around the embedder loop and `vector_db.add_chunks`. **Atomic abort (ADR-0003)**: embedder failure ends the job — `vector_db.add_chunks` is not called.
- `RAGPipeline.retrieve`: per-stage `try/except` around `embedder.embed(query)` and `retriever.retrieve(request)`.
- Plugin implementations untouched; classification stays in the pipeline.
- No backward-compatibility shims for the old `ValueError` raise sites.

## Test plan

- [x] `tests/test_errors.py` — Slice-1 hierarchy invariant test still passes; new subclasses inherit `RAGError` with non-empty `code`.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_indexer_raises_when_parser_rejects` — asserts `ParserRejected` (updated from `ValueError`).
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_indexer_raises_embedder_failed_and_skips_vector_db` — asserts `EmbedderFailed`, `__cause__` preserved, and `vector_db.add_chunks` not called.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_indexer_raises_vector_db_failed` — asserts `VectorDBFailed` with `__cause__` preserved.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_retrieve_raises_embedder_failed` — asserts `EmbedderFailed` with `__cause__` preserved.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_retrieve_raises_vector_db_failed` — asserts `VectorDBFailed` with `__cause__` preserved.
- [x] Full suite: 86 passed (pre-existing collection errors in `memory_module/integration_test.py` and `tests/parser/test_file_operations.py` are unrelated to this slice — confirmed against the base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)