### PR TITLE
Slice 3: NoChunksProduced post-chunk check (closes #10)

### DIFF
--- a/memory_module/errors.py
+++ b/memory_module/errors.py
@@ -20,3 +20,7 @@ class EmbedderFailed(RAGError):
 
 class VectorDBFailed(RAGError):
     code = "vector_db_failed"
+
+
+class NoChunksProduced(RAGError):
+    code = "no_chunks_produced"

--- a/memory_module/rag_pipeline.py
+++ b/memory_module/rag_pipeline.py
@@ -3,7 +3,14 @@ from fastapi import UploadFile
 
 from .chunking.base_chunker import BaseChunker
 from .embedder.base_embedder import BaseEmbedder
-from .errors import ConfigError, EmbedderFailed, InvalidQuery, ParserRejected, VectorDBFailed
+from .errors import (
+    ConfigError,
+    EmbedderFailed,
+    InvalidQuery,
+    NoChunksProduced,
+    ParserRejected,
+    VectorDBFailed,
+)
 from .factory.chunking_factory import get_chunker
 from .factory.embedder_factory import get_embedder
 from .factory.parser_factory import get_parser
@@ -112,6 +119,8 @@ class RAGPipeline:
 
         parsed_document = self.parser.convert(document)
         chunks = self.chunker.chunk(parsed_document, extra=metadata or {})
+        if not chunks:
+            raise NoChunksProduced("Chunker produced no chunks for the provided document.")
 
         try:
             for chunk in chunks:

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -1,7 +1,14 @@
 import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
-from memory_module.errors import ConfigError, EmbedderFailed, InvalidQuery, ParserRejected, VectorDBFailed
+from memory_module.errors import (
+    ConfigError,
+    EmbedderFailed,
+    InvalidQuery,
+    NoChunksProduced,
+    ParserRejected,
+    VectorDBFailed,
+)
 from memory_module.parser.data_models import DocumentParserResult, FileMetadata, ParsedContent
 from memory_module.rag_pipeline import RAGPipeline
 from memory_module.retrieval.data_models import RetrievalRequest, ScoredChunk
@@ -182,6 +189,20 @@ def test_indexer_raises_embedder_failed_and_skips_vector_db(upload_docx):
     assert pipeline.vector_db.added_chunks is None
 
 
+def test_retrieve_returns_empty_list_when_retriever_returns_empty():
+    class EmptyRetriever:
+        def retrieve(self, request: RetrievalRequest):
+            return []
+
+    pipeline = RAGPipeline({})
+    pipeline.embedder = StubEmbedder([0.1, 0.2])
+    pipeline.retriever = EmptyRetriever()
+
+    results = pipeline.retrieve("hello")
+
+    assert results == []
+
+
 def test_retrieve_raises_embedder_failed():
     original = RuntimeError("embedder boom")
 
@@ -218,6 +239,53 @@ def test_retrieve_raises_vector_db_failed():
         pipeline.retrieve("hello")
 
     assert exc_info.value.__cause__ is original
+
+
+def test_indexer_raises_no_chunks_produced_when_chunker_returns_empty(upload_docx):
+    parsed_document = DocumentParserResult(
+        content=ParsedContent(mode="text", text="hello world", sections=[]),
+        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
+    )
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = StubParser(parsed_document)
+    pipeline.chunker = StubChunker([])
+    pipeline.embedder = StubEmbedder([0.1, 0.2])
+    pipeline.vector_db = StubVectorDB()
+
+    with pytest.raises(NoChunksProduced):
+        pipeline.indexer(upload_docx)
+
+    assert pipeline.embedder.calls == []
+    assert pipeline.vector_db.added_chunks is None
+
+
+def test_indexer_raises_no_chunks_produced_for_empty_parsed_content(upload_docx):
+    empty_parsed = DocumentParserResult(
+        content=ParsedContent(mode="text", text="", sections=[]),
+        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
+    )
+
+    class EmptyContentChunker:
+        def __init__(self):
+            self.calls = []
+
+        def chunk(self, parsed_document, extra):
+            self.calls.append((parsed_document, extra))
+            return [] if not parsed_document.content.text else [object()]
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = StubParser(empty_parsed)
+    pipeline.chunker = EmptyContentChunker()
+    pipeline.embedder = StubEmbedder([0.1, 0.2])
+    pipeline.vector_db = StubVectorDB()
+
+    with pytest.raises(NoChunksProduced) as exc_info:
+        pipeline.indexer(upload_docx)
+
+    assert type(exc_info.value) is NoChunksProduced
+    assert pipeline.embedder.calls == []
+    assert pipeline.vector_db.added_chunks is None
 
 
 def test_indexer_raises_vector_db_failed(upload_docx):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,7 @@ import inspect
 import pytest
 
 import memory_module.errors as errors_module
-from memory_module.errors import ConfigError, InvalidQuery, RAGError
+from memory_module.errors import ConfigError, InvalidQuery, NoChunksProduced, RAGError
 
 
 def test_all_subclasses_inherit_rag_error_and_have_code():
@@ -29,3 +29,9 @@ def test_invalid_query_is_rag_error():
     exc = InvalidQuery("empty query")
     assert isinstance(exc, RAGError)
     assert InvalidQuery.code == "invalid_query"
+
+
+def test_no_chunks_produced_is_rag_error():
+    exc = NoChunksProduced("no chunks")
+    assert isinstance(exc, RAGError)
+    assert NoChunksProduced.code == "no_chunks_produced"


### PR DESCRIPTION
## Summary
- Adds `NoChunksProduced(RAGError, code="no_chunks_produced")` to `memory_module/errors.py`.
- `RAGPipeline.indexer` raises `NoChunksProduced` immediately after `chunker.chunk(...)` returns an empty list — before any embedding or vector-DB work.
- One exception type covers both root causes (empty parser content, chunker policy emitting `[]`); `retrieve()` zero-hit behavior is unchanged.

Closes #10.

## Test plan
- [x] `tests/test_errors.py` — symmetric unit test for `NoChunksProduced`; hierarchy-invariant test auto-covers the new subclass.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_indexer_raises_no_chunks_produced_when_chunker_returns_empty` — empty chunker output raises and embedder is never called.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_indexer_raises_no_chunks_produced_for_empty_parsed_content` — empty parsed content also raises (asserts identical type, not subclass).
- [x] `tests/pipeline/test_rag_pipeline_indexer.py::test_retrieve_returns_empty_list_when_retriever_returns_empty` — regression guard, zero retrieval hits still return `[]`.
- [x] Full suite green (90 passed; 2 pre-existing collection errors unrelated to this slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)