### PR TITLE
Wrap parser & chunker runtime errors with typed exceptions (#14)

### DIFF
--- a/memory_module/errors.py
+++ b/memory_module/errors.py
@@ -14,6 +14,14 @@ class ParserRejected(RAGError):
     code = "parser_rejected"
 
 
+class ParserFailed(RAGError):
+    code = "parser_failed"
+
+
+class ChunkerFailed(RAGError):
+    code = "chunker_failed"
+
+
 class EmbedderFailed(RAGError):
     code = "embedder_failed"
 

--- a/memory_module/rag_pipeline.py
+++ b/memory_module/rag_pipeline.py
@@ -4,10 +4,12 @@ from fastapi import UploadFile
 from .chunking.base_chunker import BaseChunker
 from .embedder.base_embedder import BaseEmbedder
 from .errors import (
+    ChunkerFailed,
     ConfigError,
     EmbedderFailed,
     InvalidQuery,
     NoChunksProduced,
+    ParserFailed,
     ParserRejected,
     VectorDBFailed,
 )
@@ -117,8 +119,16 @@ class RAGPipeline:
                 raise ParserRejected(f"Parser rejected the provided document: {parser_error}")
             raise ParserRejected("Parser does not accept the provided document.")
 
-        parsed_document = self.parser.convert(document)
-        chunks = self.chunker.chunk(parsed_document, extra=metadata or {})
+        try:
+            parsed_document = self.parser.convert(document)
+        except Exception as exc:
+            raise ParserFailed("Parser failed during indexing.") from exc
+
+        try:
+            chunks = self.chunker.chunk(parsed_document, extra=metadata or {})
+        except Exception as exc:
+            raise ChunkerFailed("Chunker failed during indexing.") from exc
+
         if not chunks:
             raise NoChunksProduced("Chunker produced no chunks for the provided document.")
 

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -2,10 +2,12 @@ import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
 from memory_module.errors import (
+    ChunkerFailed,
     ConfigError,
     EmbedderFailed,
     InvalidQuery,
     NoChunksProduced,
+    ParserFailed,
     ParserRejected,
     VectorDBFailed,
 )
@@ -319,6 +321,66 @@ def test_indexer_raises_vector_db_failed(upload_docx):
         pipeline.indexer(upload_docx)
 
     assert exc_info.value.__cause__ is original
+
+
+def test_indexer_raises_parser_failed_when_convert_blows_up(upload_docx):
+    original = RuntimeError("zip corruption inside docx")
+
+    class FailingConvertParser:
+        last_error = None
+
+        def __init__(self):
+            self.calls = []
+
+        def accepts(self, file_stream):
+            self.calls.append("accepts")
+            return True
+
+        def convert(self, file_stream):
+            self.calls.append("convert")
+            raise original
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = FailingConvertParser()
+    pipeline.chunker = StubChunker([])
+    pipeline.embedder = StubEmbedder([0.1])
+    pipeline.vector_db = StubVectorDB()
+
+    with pytest.raises(ParserFailed) as exc_info:
+        pipeline.indexer(upload_docx)
+
+    assert exc_info.value.__cause__ is original
+    assert not isinstance(exc_info.value, ParserRejected)
+    assert pipeline.vector_db.added_chunks is None
+
+
+def test_indexer_raises_chunker_failed_when_chunk_blows_up(upload_docx):
+    parsed_document = DocumentParserResult(
+        content=ParsedContent(mode="text", text="hello world", sections=[]),
+        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
+    )
+
+    original = ValueError("Unsupported parsed content mode: weird")
+
+    class FailingChunker:
+        def __init__(self):
+            self.calls = []
+
+        def chunk(self, parsed_document, extra):
+            self.calls.append(("chunk", parsed_document, extra))
+            raise original
+
+    pipeline = RAGPipeline({})
+    pipeline.parser = StubParser(parsed_document)
+    pipeline.chunker = FailingChunker()
+    pipeline.embedder = StubEmbedder([0.1])
+    pipeline.vector_db = StubVectorDB()
+
+    with pytest.raises(ChunkerFailed) as exc_info:
+        pipeline.indexer(upload_docx)
+
+    assert exc_info.value.__cause__ is original
+    assert pipeline.vector_db.added_chunks is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,14 @@ import inspect
 import pytest
 
 import memory_module.errors as errors_module
-from memory_module.errors import ConfigError, InvalidQuery, NoChunksProduced, RAGError
+from memory_module.errors import (
+    ChunkerFailed,
+    ConfigError,
+    InvalidQuery,
+    NoChunksProduced,
+    ParserFailed,
+    RAGError,
+)
 
 
 def test_all_subclasses_inherit_rag_error_and_have_code():
@@ -35,3 +42,20 @@ def test_no_chunks_produced_is_rag_error():
     exc = NoChunksProduced("no chunks")
     assert isinstance(exc, RAGError)
     assert NoChunksProduced.code == "no_chunks_produced"
+
+
+def test_parser_failed_is_rag_error():
+    exc = ParserFailed("parser blew up")
+    assert isinstance(exc, RAGError)
+    assert ParserFailed.code == "parser_failed"
+
+
+def test_chunker_failed_is_rag_error():
+    exc = ChunkerFailed("chunker blew up")
+    assert isinstance(exc, RAGError)
+    assert ChunkerFailed.code == "chunker_failed"
+
+
+def test_parser_failed_and_parser_rejected_are_distinct():
+    assert ParserFailed is not errors_module.ParserRejected
+    assert ParserFailed.code != errors_module.ParserRejected.code


### PR DESCRIPTION
## Summary

- Adds `ParserFailed` (code: `parser_failed`) and `ChunkerFailed` (code: `chunker_failed`) to `memory_module/errors.py`, both subclassing `RAGError`.
- Wraps `parser.convert(...)` and `chunker.chunk(...)` in `RAGPipeline.indexer` so runtime failures (e.g. `BadZipFile` from python-docx, `ValueError("Unsupported parsed content mode...")` from the chunker) surface as typed errors with the original exception preserved on `__cause__`.
- `ParserRejected` semantics are unchanged — it still only fires when `parser.accepts()` returns `False`.

Closes #14

## Test plan

- [x] `tests/test_errors.py` — added assertions that `ParserFailed`/`ChunkerFailed` are `RAGError` subclasses with their declared codes, and that `ParserFailed` is distinct from `ParserRejected`.
- [x] `tests/pipeline/test_rag_pipeline_indexer.py` — added `test_indexer_raises_parser_failed_when_convert_blows_up` and `test_indexer_raises_chunker_failed_when_chunk_blows_up`; both assert the original exception is preserved on `__cause__` and that the vector DB is not touched after a stage failure.
- [x] Existing `test_indexer_raises_when_parser_rejects` still passes — `ParserRejected` flow unchanged.
- [x] Full suite: 95 passed (two pre-existing collection errors in `tests/parser/test_file_operations.py` and `memory_module/integration_test.py` exist on `main` and are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)