### PR TITLE
add_chunks: best-effort compensating delete + ADR 0001

### DIFF
--- a/docs/adr/0001-add-chunks-atomicity.md
+++ b/docs/adr/0001-add-chunks-atomicity.md
@@ -1,0 +1,70 @@
+# ADR 0001: `add_chunks` atomicity model
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+`RAGPipeline.indexer` calls `vector_db.add_chunks(chunks)` as its final stage.
+The current backing implementation, `QdrantVectorMemory.add_chunks`
+(`memory_module/vector_db/qdrant_vector_db.py`), issues one batched
+`client.upsert(points=[...], wait=True)` call.
+
+Qdrant's `upsert` is **not transactional across a batch**. If the call fails
+partway (network drop, server-side error mid-batch), some points in the batch
+may already be persisted while others are not. The indexer then re-raises the
+underlying failure as `VectorDBFailed`, but the caller has no signal about
+whether the collection now contains a partial write.
+
+The Slice 2 commit (`03c923e`, "Slice 2: stage-failure errors ... + atomic
+abort") uses the phrase "atomic abort". That phrase refers only to
+**pre-`add_chunks` atomicity** — an embedder failure ends the indexer job
+before `add_chunks` is called, so the vector DB is untouched. It does **not**
+claim that `add_chunks` itself is atomic. This ADR exists partly to reconcile
+that ambiguous phrasing with the actual contract.
+
+## Decision
+
+`add_chunks` provides a **best-effort compensating delete** guarantee.
+
+On any exception raised by the underlying `upsert`, the implementation issues a
+`delete` for every `chunk_id` in the batch and then re-raises the original
+failure wrapped as `RuntimeError` (which the pipeline layer wraps as
+`VectorDBFailed`). The compensating delete is itself best-effort: if it also
+raises, its exception is swallowed and the original upsert error is still what
+surfaces.
+
+Concretely, the contract callers can rely on:
+
+- **Success path**: the batch is persisted; no delete is issued.
+- **Failure path**: `VectorDBFailed` (or, at the vector-db-layer boundary,
+  `RuntimeError("Failed to add chunks to Qdrant: ...")`) is raised, and the
+  implementation has made a best-effort attempt to remove any points from the
+  failed batch. In the rare case both the upsert and the compensating delete
+  fail, orphan points may remain in the collection. Callers that need a
+  stronger guarantee should dedupe by `chunk_id` on retry.
+
+## Considered alternatives
+
+1. **Best-effort, no cleanup.** Accept partial state on failure; document it.
+   Zero code cost, weakest guarantee. Rejected because the extra round-trip on
+   the failure path is cheap and materially reduces orphan probability.
+2. **Per-point upsert with rollback tracking.** Upsert points one-by-one, track
+   successes, delete succeeded IDs on failure. Rejected: pays a per-point
+   network round-trip on the success path (N× latency for a batch of N
+   chunks), and still doesn't provide true ACID — a process crash between
+   "upsert of point k succeeded" and "record k in success list" still loses
+   track. The extra guarantee didn't justify the latency cost.
+
+## Consequences
+
+- The pipeline continues to raise `VectorDBFailed` when `add_chunks` fails.
+  Callers should treat that as "the batch was rejected; the DB has been
+  best-effort restored to its pre-call state, but you should still dedupe by
+  `chunk_id` on retry."
+- The "atomic abort" phrasing in commit `03c923e` should be read as
+  "pre-`add_chunks` atomicity only". This ADR is the authoritative source for
+  the `add_chunks` contract.
+- Future vector-db backends implementing `BaseVectorMemory.add_chunks` should
+  honor this same contract: on failure, attempt to remove the batch's IDs
+  before re-raising.

--- a/memory_module/vector_db/qdrant_vector_db.py
+++ b/memory_module/vector_db/qdrant_vector_db.py
@@ -113,6 +113,16 @@ class QdrantVectorMemory(BaseVectorMemory):
                 wait=True
             )
         except Exception as e:
+            # Best-effort compensating delete for the batch's ids. See
+            # docs/adr/0001-add-chunks-atomicity.md for the contract.
+            try:
+                self.vector_client.delete(
+                    collection_name=self.collection_name,
+                    points_selector=[chunk.chunk_id for chunk in chunks],
+                    wait=True,
+                )
+            except Exception:
+                pass
             raise RuntimeError(f"Failed to add chunks to Qdrant: {str(e)}")
 
     def retrieve(

--- a/tests/vector_db/test_qdrant_vector_db.py
+++ b/tests/vector_db/test_qdrant_vector_db.py
@@ -64,6 +64,14 @@ def test_add_chunks_serializes_current_payload_shape(mock_qdrant_client, sample_
     assert points[0].payload["metadata"]["document_id"] == "doc-1"
 
 
+def test_add_chunks_does_not_delete_on_success(mock_qdrant_client, sample_chunks):
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+
+    memory.add_chunks(sample_chunks)
+
+    mock_qdrant_client.delete.assert_not_called()
+
+
 def test_retrieve_returns_scored_chunks_with_scores(mock_qdrant_client):
     mock_qdrant_client.search.return_value = [
         SimpleNamespace(
@@ -142,5 +150,29 @@ def test_add_chunks_wraps_client_errors(mock_qdrant_client, sample_chunks):
     memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
 
     with pytest.raises(RuntimeError, match="Failed to add chunks to Qdrant"):
+        memory.add_chunks(sample_chunks)
+
+
+def test_add_chunks_compensates_by_deleting_batch_ids_on_upsert_failure(
+    mock_qdrant_client, sample_chunks
+):
+    mock_qdrant_client.upsert.side_effect = Exception("boom")
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+
+    with pytest.raises(RuntimeError, match="Failed to add chunks to Qdrant"):
+        memory.add_chunks(sample_chunks)
+
+    mock_qdrant_client.delete.assert_called_once()
+    assert mock_qdrant_client.delete.call_args.kwargs["points_selector"] == ["chunk-1"]
+
+
+def test_add_chunks_surfaces_original_error_when_compensating_delete_also_fails(
+    mock_qdrant_client, sample_chunks
+):
+    mock_qdrant_client.upsert.side_effect = Exception("upsert boom")
+    mock_qdrant_client.delete.side_effect = Exception("delete boom")
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+
+    with pytest.raises(RuntimeError, match="upsert boom"):
         memory.add_chunks(sample_chunks)
 


### PR DESCRIPTION
## Summary
- Chose **Option 2 (compensating delete)** from issue #16 and recorded the decision in `docs/adr/0001-add-chunks-atomicity.md`.
- `QdrantVectorMemory.add_chunks` now issues a best-effort `delete` for the batch's `chunk_id`s when the underlying `upsert` fails, before re-raising the original error. If the compensating delete itself fails, its exception is swallowed and the original upsert error still surfaces — the delete never masks the real failure.
- ADR reconciles the ambiguous "atomic abort" phrasing from commit `03c923e` (which only covered pre-`add_chunks` stages) with the new `add_chunks`-layer contract.

Closes #16

## Test plan
- [x] `test_add_chunks_compensates_by_deleting_batch_ids_on_upsert_failure` — delete called with the batch's ids, original error re-raised.
- [x] `test_add_chunks_surfaces_original_error_when_compensating_delete_also_fails` — delete's exception is swallowed; caller sees the upsert error.
- [x] `test_add_chunks_does_not_delete_on_success` — regression guard.
- [x] Existing `test_add_chunks_wraps_client_errors` still passes.
- [x] Full suite: 93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)