### PR TITLE
Tighten BaseEmbedder.embed return-type contract (#17)

### DIFF
--- a/memory_module/embedder/azure_open_ai_embedder.py
+++ b/memory_module/embedder/azure_open_ai_embedder.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from .base_embedder import BaseEmbedder
+from ..errors import EmbedderFailed
 
 load_dotenv()
 
@@ -41,13 +42,16 @@ class AzureEmbeddingGenerator(BaseEmbedder):
             base_url=self.base_url,
         )
 
-    def embed(self, text: str) -> List[List[float]]:
+    def embed(self, text: str) -> List[float]:
         """
-        Generates embeddings for a string.
+        Generates a single embedding vector for a string.
         """
         response = self.client.embeddings.create(
             model=self.model,
             input=text,
         )
-        embeddings = [d.embedding for d in response.data]
-        return embeddings
+        if not response.data:
+            raise EmbedderFailed(
+                "Azure embedder returned no embeddings for the input text."
+            )
+        return response.data[0].embedding

--- a/memory_module/embedder/base_embedder.py
+++ b/memory_module/embedder/base_embedder.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Union, List
+from typing import List
 
 class BaseEmbedder(ABC):
     @abstractmethod
-    def embed(self, text: str) -> Union[List[float]]:
+    def embed(self, text: str) -> List[float]:
         pass

--- a/memory_module/rag_pipeline.py
+++ b/memory_module/rag_pipeline.py
@@ -134,10 +134,7 @@ class RAGPipeline:
 
         try:
             for chunk in chunks:
-                embedding = self.embedder.embed(chunk.text)
-                if embedding and isinstance(embedding[0], list):
-                    embedding = embedding[0]
-                chunk.embedding = embedding
+                chunk.embedding = self.embedder.embed(chunk.text)
         except Exception as exc:
             raise EmbedderFailed("Embedder failed during indexing.") from exc
 
@@ -166,8 +163,6 @@ class RAGPipeline:
             embedded_query = self.embedder.embed(query)
         except Exception as exc:
             raise EmbedderFailed("Embedder failed on the query.") from exc
-        if embedded_query and isinstance(embedded_query[0], list):
-            embedded_query = embedded_query[0]
 
         request = RetrievalRequest(
             query_text=query,

--- a/tests/embedder/test_azure_embedder.py
+++ b/tests/embedder/test_azure_embedder.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+import pytest
+
+from memory_module.embedder.azure_open_ai_embedder import AzureEmbeddingGenerator
+from memory_module.errors import EmbedderFailed
+
+
+class _StubOpenAIEmbeddings:
+    def __init__(self, response):
+        self._response = response
+
+    def create(self, *, model, input):
+        return self._response
+
+
+class _StubOpenAIClient:
+    def __init__(self, response):
+        self.embeddings = _StubOpenAIEmbeddings(response)
+
+
+def _make_embedder(response) -> AzureEmbeddingGenerator:
+    embedder = AzureEmbeddingGenerator(
+        api_key="test-key",
+        base_url="https://example.invalid/",
+        model="test-model",
+    )
+    embedder.client = _StubOpenAIClient(response)
+    return embedder
+
+
+def test_embed_returns_flat_list_of_floats():
+    response = SimpleNamespace(data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])])
+    embedder = _make_embedder(response)
+
+    result = embedder.embed("hello")
+
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_raises_embedder_failed_when_response_data_empty():
+    response = SimpleNamespace(data=[])
+    embedder = _make_embedder(response)
+
+    with pytest.raises(EmbedderFailed):
+        embedder.embed("hello")

--- a/tests/pipeline/test_rag_pipeline_indexer.py
+++ b/tests/pipeline/test_rag_pipeline_indexer.py
@@ -49,32 +49,6 @@ def test_indexer_calls_components_in_order(upload_docx):
     assert result[0].embedding == [0.1, 0.2]
 
 
-def test_indexer_flattens_batch_embedding(upload_docx):
-    parsed_document = DocumentParserResult(
-        content=ParsedContent(mode="text", text="hello world", sections=[]),
-        file_metadata=FileMetadata(document_id="doc_1", document_title="Doc 1"),
-    )
-    chunks = [
-        Chunk(
-            chunk_id="chunk_1",
-            text="hello",
-            embedding=[],
-            metadata=ChunkMetadata(document_id="doc_1", chunk_version="doc_1_chunk_1"),
-            token_count=5,
-        )
-    ]
-
-    pipeline = RAGPipeline({})
-    pipeline.parser = StubParser(parsed_document)
-    pipeline.chunker = StubChunker(chunks)
-    pipeline.embedder = StubEmbedder([[0.1, 0.2]])
-    pipeline.vector_db = StubVectorDB()
-
-    result = pipeline.indexer(upload_docx)
-
-    assert result[0].embedding == [0.1, 0.2]
-
-
 def test_retrieve_returns_scored_chunks(sample_chunk):
     scored = ScoredChunk(chunk=sample_chunk, score=0.9)
 
@@ -103,24 +77,6 @@ def test_retrieve_returns_scored_chunks(sample_chunk):
     assert req.query_embedding == [0.3, 0.4]
     assert req.top_k == 3
     assert req.filters == {"tags": "x"}
-
-
-def test_retrieve_flattens_batch_embeddings(sample_chunk):
-    scored = ScoredChunk(chunk=sample_chunk, score=0.5)
-
-    class RetrieveStrategy:
-        def retrieve(self, request: RetrievalRequest):
-            self.request = request
-            return [scored]
-
-    pipeline = RAGPipeline({})
-    pipeline.embedder = StubEmbedder([[0.3, 0.4]])
-    pipeline.retriever = RetrieveStrategy()
-    pipeline.vector_db = StubVectorDB()
-
-    pipeline.retrieve("hello")
-
-    assert pipeline.retriever.request.query_embedding == [0.3, 0.4]
 
 
 def test_retrieve_requires_embedder_and_retrieval_strategy():


### PR DESCRIPTION
Closes #17.

## Summary
- `BaseEmbedder.embed` now correctly declares `-> List[float]` (drops the meaningless `Union[List[float]]`).
- `AzureEmbeddingGenerator.embed` returns `response.data[0].embedding` directly and raises `EmbedderFailed` if `response.data` is empty.
- `RAGPipeline.indexer` and `RAGPipeline.retrieve` no longer contain the `isinstance(embedding[0], list)` flatten workaround — the embedder contract is now honest, so callers don't need to compensate.

## Tests
- Removed obsolete `test_indexer_flattens_batch_embedding` and `test_retrieve_flattens_batch_embeddings`; the existing positive-path pipeline tests (`test_indexer_calls_components_in_order`, `test_retrieve_returns_scored_chunks`) already assert the flat-list contract.
- Added `tests/embedder/test_azure_embedder.py` with two tests:
  - `test_embed_returns_flat_list_of_floats` — confirms flat return.
  - `test_embed_raises_embedder_failed_when_response_data_empty` — confirms typed error on empty `response.data`.

## Test plan
- [x] `pytest tests/embedder/ tests/pipeline/` — 29 passed
- [x] Full suite (excluding two pre-existing broken collectors unrelated to this change) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)