### PR TITLE
Replace deprecated datetime.utcnow() calls

### DIFF
--- a/memory_module/chunking/data_models.py
+++ b/memory_module/chunking/data_models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class ChunkMetadata(BaseModel):
@@ -8,7 +8,7 @@ class ChunkMetadata(BaseModel):
     document_title: Optional[str] = None # Optional human-readable title
     tags: Optional[List[str]] = None     # Custom tags like "finance", "HR", etc.
     chunk_version: Optional[str] = None  # Versioning support
-    created_at: datetime = Field(default_factory=datetime.utcnow) # When this chunk was created
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc)) # When this chunk was created
 
 class Chunk(BaseModel):
     chunk_id: str                         # Unique ID for the chunk

--- a/memory_module/vector_db/qdrant_vector_db.py
+++ b/memory_module/vector_db/qdrant_vector_db.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 from dotenv import load_dotenv
@@ -186,12 +186,12 @@ class QdrantVectorMemory(BaseVectorMemory):
                 text = payload.get("text", "")
                 metadata_dict = payload.get("metadata", {})
                 created_at_value = metadata_dict.get("created_at")
-                created_at = datetime.now()
+                created_at = datetime.now(timezone.utc)
                 if isinstance(created_at_value, str):
                     try:
                         created_at = datetime.fromisoformat(created_at_value)
                     except ValueError:
-                        created_at = datetime.utcnow()
+                        created_at = datetime.now(timezone.utc)
 
                 metadata = ChunkMetadata(
                     document_id=metadata_dict.get("document_id", ""),

--- a/tests/chunking/test_data_models.py
+++ b/tests/chunking/test_data_models.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import pytest
 
 from memory_module.chunking.data_models import Chunk, ChunkMetadata
@@ -26,4 +28,11 @@ def test_chunk_requires_current_simplified_fields():
 
     assert chunk.chunk_id == "chunk1"
     assert chunk.token_count == 5
+
+
+def test_chunk_metadata_created_at_default_is_timezone_aware_utc():
+    metadata = ChunkMetadata(document_id="doc1")
+
+    assert metadata.created_at.tzinfo is not None
+    assert metadata.created_at.utcoffset() == timezone.utc.utcoffset(metadata.created_at)
 

--- a/tests/vector_db/test_qdrant_vector_db.py
+++ b/tests/vector_db/test_qdrant_vector_db.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -36,7 +36,7 @@ def sample_chunks():
                 document_title="Doc 1",
                 tags=["a"],
                 chunk_version="doc-1_chunk_1",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             ),
             token_count=5,
         )
@@ -85,7 +85,7 @@ def test_retrieve_returns_scored_chunks_with_scores(mock_qdrant_client):
                     "document_title": "Doc 1",
                     "tags": ["a"],
                     "chunk_version": "doc-1_chunk_1",
-                    "created_at": datetime.utcnow().isoformat(),
+                    "created_at": datetime.now(timezone.utc).isoformat(),
                 },
             },
             vector=[0.1, 0.2],
@@ -175,4 +175,61 @@ def test_add_chunks_surfaces_original_error_when_compensating_delete_also_fails(
 
     with pytest.raises(RuntimeError, match="upsert boom"):
         memory.add_chunks(sample_chunks)
+
+
+def _search_result_with_metadata(metadata: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="chunk-1",
+        score=0.5,
+        payload={"text": "x", "token_count": 1, "metadata": metadata},
+        vector=[],
+    )
+
+
+def test_retrieve_created_at_fallback_is_timezone_aware_when_missing(mock_qdrant_client):
+    mock_qdrant_client.search.return_value = [
+        _search_result_with_metadata({"document_id": "doc-1"})
+    ]
+
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+    results = memory.retrieve([0.1, 0.2], top_k=1)
+
+    assert results[0].chunk.metadata.created_at.tzinfo is not None
+    assert results[0].chunk.metadata.created_at.utcoffset() == timezone.utc.utcoffset(
+        results[0].chunk.metadata.created_at
+    )
+
+
+def test_retrieve_created_at_fallback_is_timezone_aware_when_unparseable(mock_qdrant_client):
+    mock_qdrant_client.search.return_value = [
+        _search_result_with_metadata({"document_id": "doc-1", "created_at": "not-a-date"})
+    ]
+
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+    results = memory.retrieve([0.1, 0.2], top_k=1)
+
+    assert results[0].chunk.metadata.created_at.tzinfo is not None
+    assert results[0].chunk.metadata.created_at.utcoffset() == timezone.utc.utcoffset(
+        results[0].chunk.metadata.created_at
+    )
+
+
+@pytest.mark.parametrize(
+    "iso_string",
+    [
+        "2025-01-02T03:04:05",         # legacy naive payload
+        "2025-01-02T03:04:05+00:00",   # new tz-aware payload
+    ],
+)
+def test_retrieve_parses_iso_created_at_from_payload(mock_qdrant_client, iso_string):
+    mock_qdrant_client.search.return_value = [
+        _search_result_with_metadata({"document_id": "doc-1", "created_at": iso_string})
+    ]
+
+    memory = QdrantVectorMemory(collection_name="test_collection", vector_size=2)
+    results = memory.retrieve([0.1, 0.2], top_k=1)
+
+    parsed = results[0].chunk.metadata.created_at
+    assert (parsed.year, parsed.month, parsed.day) == (2025, 1, 2)
+    assert (parsed.hour, parsed.minute, parsed.second) == (3, 4, 5)
 


### PR DESCRIPTION
## Summary
- Replace `datetime.utcnow()` (deprecated in Python 3.12+, and this project pins `>=3.13`) with timezone-aware `datetime.now(timezone.utc)` at all three call sites: `ChunkMetadata.created_at` default factory, and both `created_at` fallbacks in `QdrantVectorMemory.retrieve`.
- Existing `datetime.fromisoformat` handles both legacy naive payloads and new tz-suffixed payloads, so older Qdrant records continue to parse.
- Also fix two `datetime.utcnow()` uses inside `tests/vector_db/test_qdrant_vector_db.py` so the suite emits no `DeprecationWarning` for `utcnow`.

Built via TDD in 4 red→green cycles — one test per behavior.

Closes #22

## Test plan
- [x] `ChunkMetadata()` default `created_at` is tz-aware UTC — `tests/chunking/test_data_models.py::test_chunk_metadata_created_at_default_is_timezone_aware_utc`
- [x] Retrieve fallback when payload is missing `created_at` is tz-aware — `test_retrieve_created_at_fallback_is_timezone_aware_when_missing`
- [x] Retrieve fallback when payload `created_at` is unparseable is tz-aware — `test_retrieve_created_at_fallback_is_timezone_aware_when_unparseable`
- [x] Retrieve parses both legacy naive (`2025-01-02T03:04:05`) and tz-aware (`2025-01-02T03:04:05+00:00`) ISO strings — parametrized `test_retrieve_parses_iso_created_at_from_payload`
- [x] Full suite runs clean under `pytest -W error::DeprecationWarning` (104 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)