### PR TITLE
Add logging setup and request correlation middleware

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,10 +12,14 @@ from memory_module.factory.embedder_factory import list_embedders
 from memory_module.factory.parser_factory import list_parsers
 from memory_module.factory.retrieval_factory import list_retrieval_strategies
 from memory_module.factory.vector_db_factory import list_vector_dbs
+from memory_module.logging_config import configure_logging
+from memory_module.logging_correlation import RequestIDMiddleware
 from memory_module.rag_pipeline import RAGPipeline
 
 
+configure_logging()
 app = FastAPI()
+app.add_middleware(RequestIDMiddleware)
 BASE_DIR = Path(__file__).resolve().parent
 DASHBOARD_DIR = BASE_DIR / "dashboard"
 

--- a/memory_module/logging_config.py
+++ b/memory_module/logging_config.py
@@ -1,0 +1,74 @@
+"""Logging setup for entrypoints (API, CLI).
+
+Env-driven. Library modules must NOT call this — they only obtain loggers
+via ``logging.getLogger(__name__)``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from memory_module.logging_correlation import (
+    RequestIDFilter,
+    get_request_id,
+)
+
+_HANDLER_MARKER = "_memory_module_stdout_handler"
+_factory_installed = False
+
+
+def _install_request_id_record_factory() -> None:
+    global _factory_installed
+    if _factory_installed:
+        return
+
+    previous = logging.getLogRecordFactory()
+
+    def factory(*args, **kwargs):
+        record = previous(*args, **kwargs)
+        record.request_id = get_request_id() or "-"
+        return record
+
+    logging.setLogRecordFactory(factory)
+    _factory_installed = True
+
+
+def _remove_marked_handlers(root: logging.Logger) -> None:
+    for handler in list(root.handlers):
+        if getattr(handler, _HANDLER_MARKER, False):
+            root.removeHandler(handler)
+
+
+def configure_logging(level: str | None = None, log_format: str | None = None) -> None:
+    """Configure process-wide logging. Idempotent; safe to call multiple times.
+
+    Reads ``LOG_LEVEL`` (default ``INFO``) and ``LOG_FORMAT`` (default ``text``).
+    Currently only ``text`` output is emitted; the ``LOG_FORMAT`` seam is
+    reserved for a later JSON slice.
+    """
+    resolved_level = (level or os.getenv("LOG_LEVEL") or "INFO").upper()
+    resolved_format = (log_format or os.getenv("LOG_FORMAT") or "text").lower()
+    if resolved_format != "text":
+        raise ValueError(
+            f"LOG_FORMAT={resolved_format!r} is not yet supported; only 'text' is available."
+        )
+
+    _install_request_id_record_factory()
+
+    root = logging.getLogger()
+    root.setLevel(resolved_level)
+
+    _remove_marked_handlers(root)
+    handler = logging.StreamHandler(sys.stdout)
+    setattr(handler, _HANDLER_MARKER, True)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s"
+        )
+    )
+    handler.addFilter(RequestIDFilter())
+    root.addHandler(handler)
+
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/memory_module/logging_correlation.py
+++ b/memory_module/logging_correlation.py
@@ -1,0 +1,112 @@
+"""Request correlation: request-scoped ID, ASGI middleware, and logging filter.
+
+Library-safe: importing this module does not configure logging handlers.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import re
+import secrets
+import time
+
+_REQUEST_ID_HEADER = b"x-request-id"
+_access_logger = logging.getLogger("memory_module.access")
+_MAX_ID_LEN = 64
+_ALLOWED_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+_request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "memory_module_request_id", default=None
+)
+
+
+def get_request_id() -> str | None:
+    """Return the current request's ID, or None if outside a request."""
+    return _request_id_var.get()
+
+
+def _generate_request_id() -> str:
+    return secrets.token_hex(4)
+
+
+def _sanitize_inbound_id(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    if not (1 <= len(raw) <= _MAX_ID_LEN):
+        return None
+    if not _ALLOWED_ID_RE.match(raw):
+        return None
+    return raw
+
+
+def _extract_inbound_id(scope) -> str | None:
+    for name, value in scope.get("headers", ()):
+        if name == _REQUEST_ID_HEADER:
+            try:
+                return value.decode("latin-1")
+            except UnicodeDecodeError:
+                return None
+    return None
+
+
+class RequestIDMiddleware:
+    """Pure-ASGI middleware that stamps every request with a short request ID.
+
+    The ID is available to every log record via RequestIDFilter and is echoed
+    back in the ``X-Request-ID`` response header.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        inbound = _sanitize_inbound_id(_extract_inbound_id(scope))
+        request_id = inbound if inbound is not None else _generate_request_id()
+        token = _request_id_var.set(request_id)
+        header_value = request_id.encode("latin-1")
+
+        status_holder: dict[str, int] = {"code": 0}
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                status_holder["code"] = message.get("status", 0)
+                headers = list(message.get("headers", []))
+                headers.append((b"x-request-id", header_value))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        started = time.perf_counter()
+        try:
+            await self.app(scope, receive, send_with_header)
+        finally:
+            duration_ms = round((time.perf_counter() - started) * 1000, 3)
+            method = scope.get("method", "")
+            path = scope.get("path", "")
+            status_code = status_holder["code"]
+            _access_logger.info(
+                "%s %s %s %sms",
+                method,
+                path,
+                status_code,
+                duration_ms,
+                extra={
+                    "method": method,
+                    "path": path,
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
+            _request_id_var.reset(token)
+
+
+class RequestIDFilter(logging.Filter):
+    """Attach the current request ID to every log record as ``request_id``."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id_var.get() or "-"
+        return True

--- a/tests/logging/test_request_correlation.py
+++ b/tests/logging/test_request_correlation.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import main
+from memory_module.logging_config import configure_logging
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_response_carries_generated_request_id_header():
+    client = TestClient(main.app)
+    response = client.get("/strategies/parsers")
+
+    assert response.status_code in (200, 404)
+    request_id = response.headers.get("x-request-id")
+    assert request_id is not None
+    assert request_id != ""
+
+
+def test_sanitized_inbound_request_id_is_echoed():
+    client = TestClient(main.app)
+    inbound = "abc-123_def.XYZ"
+    response = client.get(
+        "/strategies/parsers",
+        headers={"X-Request-ID": inbound},
+    )
+
+    assert response.headers.get("x-request-id") == inbound
+
+
+def test_malformed_inbound_request_id_is_replaced():
+    client = TestClient(main.app)
+    too_long = "a" * 65
+    malformed_cases = [
+        "has spaces",
+        "has/slash",
+        "has;semicolon",
+        too_long,
+    ]
+
+    for malformed in malformed_cases:
+        response = client.get(
+            "/strategies/parsers",
+            headers={"X-Request-ID": malformed},
+        )
+        returned = response.headers.get("x-request-id")
+        assert returned is not None
+        assert returned != malformed
+        assert 1 <= len(returned) <= 64
+
+
+def test_sequential_requests_get_distinct_ids():
+    client = TestClient(main.app)
+    ids = {
+        client.get("/strategies/parsers").headers["x-request-id"]
+        for _ in range(5)
+    }
+
+    assert len(ids) == 5
+
+
+def test_records_emitted_during_request_carry_request_id(monkeypatch, caplog):
+    configure_logging()
+    module_logger = logging.getLogger("memory_module.test_correlation")
+
+    def emit_and_return():
+        module_logger.info("processing")
+        return ["docx"]
+
+    monkeypatch.setattr(main, "list_parsers", emit_and_return)
+    main.STRATEGY_LISTERS = {**main.STRATEGY_LISTERS, "parsers": main.list_parsers}
+
+    client = TestClient(main.app)
+    caplog.set_level(logging.INFO, logger="memory_module.test_correlation")
+
+    response = client.get("/strategies/parsers")
+    outbound_id = response.headers["x-request-id"]
+
+    matching = [r for r in caplog.records if r.name == "memory_module.test_correlation"]
+    assert matching, "expected at least one memory_module log record"
+    for record in matching:
+        assert getattr(record, "request_id", None) == outbound_id
+
+
+def test_one_access_summary_line_per_request(caplog):
+    configure_logging()
+    client = TestClient(main.app)
+    caplog.set_level(logging.INFO, logger="memory_module.access")
+
+    response = client.get("/strategies/parsers")
+    outbound_id = response.headers["x-request-id"]
+
+    access_records = [r for r in caplog.records if r.name == "memory_module.access"]
+    assert len(access_records) == 1
+    record = access_records[0]
+    assert record.levelno == logging.INFO
+    assert getattr(record, "request_id", None) == outbound_id
+    assert getattr(record, "method", None) == "GET"
+    assert getattr(record, "path", None) == "/strategies/parsers"
+    assert getattr(record, "status_code", None) == response.status_code
+    duration_ms = getattr(record, "duration_ms", None)
+    assert isinstance(duration_ms, (int, float))
+    assert duration_ms >= 0
+
+
+def test_log_level_env_drives_root_level(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    configure_logging()
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    configure_logging()
+    assert logging.getLogger().getEffectiveLevel() == logging.INFO
+
+
+def test_configure_logging_is_idempotent():
+    configure_logging()
+    handlers_before = len(logging.getLogger().handlers)
+    for _ in range(4):
+        configure_logging()
+    handlers_after = len(logging.getLogger().handlers)
+    assert handlers_after == handlers_before
+
+
+def test_importing_memory_module_does_not_configure_logging():
+    script = textwrap.dedent(
+        """
+        import json
+        import logging
+
+        before = len(logging.getLogger().handlers)
+        import memory_module  # noqa: F401
+        after = len(logging.getLogger().handlers)
+        print(json.dumps({"before": before, "after": after}))
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    import json as _json
+    payload = _json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["after"] == payload["before"]


### PR DESCRIPTION
## Summary

Tracer bullet for issue #33: a request hits the API and produces one correlated INFO summary line, and the response carries the request ID.

- `memory_module/logging_config.py` — `configure_logging()` reads `LOG_LEVEL` (default `INFO`) and `LOG_FORMAT` (only `text` supported this slice; validates the seam), installs a stdout `StreamHandler`, raises `uvicorn.access` to `WARNING`, and is idempotent. Called only by the API entrypoint.
- `memory_module/logging_correlation.py` — pure-ASGI `RequestIDMiddleware` that sanitizes an inbound `X-Request-ID` (`[A-Za-z0-9._-]{1,64}`) or falls back to `secrets.token_hex(4)` (8 hex chars), sets a `ContextVar`, emits an `X-Request-ID` response header, and emits one `INFO` line on `memory_module.access` with method, path, status, and `duration_ms`. Also exports `get_request_id()` and `RequestIDFilter`. A `LogRecordFactory` installed by `configure_logging()` stamps every record with `request_id` so records from any logger (including `memory_module.*`) carry the current ID.
- `main.py` — calls `configure_logging()` and installs the middleware.
- `tests/logging/test_request_correlation.py` — TestClient + `caplog` coverage for header round-trip, sanitization, malformed replacement, distinct IDs, cross-logger record stamping, per-request summary line, `LOG_LEVEL` wiring, idempotence, and library non-configuration (subprocess-level check that importing `memory_module` adds no handlers).

Closes #33.

## Test plan

- [x] `uv run pytest tests/logging -q` — 9 passed
- [x] `uv run pytest -q` — 122 passed, 1 skipped (no regressions)
- [ ] Manual smoke: `uv run uvicorn main:app` and `curl -i http://127.0.0.1:8000/strategies` shows an `X-Request-ID` header and one summary INFO line per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)